### PR TITLE
Fix email normalization and registration error handling

### DIFF
--- a/api/src/main/java/com/blanchaert/quizle/controller/UserController.java
+++ b/api/src/main/java/com/blanchaert/quizle/controller/UserController.java
@@ -2,6 +2,7 @@ package com.blanchaert.quizle.controller;
 
 import com.blanchaert.quizle.domain.user.UserService;
 import com.blanchaert.quizle.dto.UserRegistrationRequest;
+import com.blanchaert.quizle.exception.UserAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -23,7 +24,7 @@ public class UserController {
         try {
             userService.registerUser(request);
             return ResponseEntity.ok("User registered successfully");
-        } catch (IllegalArgumentException ex) {
+        } catch (UserAlreadyExistsException ex) {
             return ResponseEntity.badRequest().body(ex.getMessage());
         }
     }

--- a/api/src/main/java/com/blanchaert/quizle/domain/user/UserService.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/user/UserService.java
@@ -15,17 +15,19 @@ public class UserService {
     private final BCryptPasswordEncoder passwordEncoder;
 
     public void registerUser(UserRegistrationRequest request) {
+        String normalizedEmail = request.getEmail().trim().toLowerCase(Locale.ROOT);
+
         if (userRepository.existsByUsername(request.getUsername())) {
             throw new UserAlreadyExistsException("Username already taken");
         }
 
-        if (userRepository.existsByEmail(request.getEmail())) {
+        if (userRepository.existsByEmail(normalizedEmail)) {
             throw new UserAlreadyExistsException("Email already in use");
         }
 
         User user = new User();
         user.setUsername(request.getUsername());
-        user.setEmail(request.getEmail().trim().toLowerCase(Locale.ROOT));
+        user.setEmail(normalizedEmail);
         user.setRole(Role.USER);
         user.setPasswordHash(passwordEncoder.encode(request.getPassword()));
 

--- a/api/src/test/java/com/blanchaert/quizle/domain/user/UserServiceUnitTest.java
+++ b/api/src/test/java/com/blanchaert/quizle/domain/user/UserServiceUnitTest.java
@@ -1,6 +1,7 @@
 package com.blanchaert.quizle.domain.user;
 
 import com.blanchaert.quizle.dto.UserRegistrationRequest;
+import com.blanchaert.quizle.exception.UserAlreadyExistsException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -63,11 +64,11 @@ public class UserServiceUnitTest {
 
         when(userRepository.existsByUsername("existinguser")).thenReturn(true);
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+        UserAlreadyExistsException exception = assertThrows(UserAlreadyExistsException.class, () ->
                 userService.registerUser(request)
         );
 
-        assertEquals("User with same username or email already exists", exception.getMessage());
+        assertEquals("Username already taken", exception.getMessage());
         verify(userRepository, never()).save(any());
     }
 
@@ -81,11 +82,29 @@ public class UserServiceUnitTest {
         when(userRepository.existsByUsername("newuser")).thenReturn(false);
         when(userRepository.existsByEmail("existing@example.com")).thenReturn(true);
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+        UserAlreadyExistsException exception = assertThrows(UserAlreadyExistsException.class, () ->
                 userService.registerUser(request)
         );
 
-        assertEquals("User with same username or email already exists", exception.getMessage());
+        assertEquals("Email already in use", exception.getMessage());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void registerUser_checksEmailExistenceAfterNormalization() {
+        UserRegistrationRequest request = new UserRegistrationRequest();
+        request.setUsername("anotheruser");
+        request.setEmail(" Existing@Example.com \n");
+        request.setPassword("123");
+
+        when(userRepository.existsByUsername("anotheruser")).thenReturn(false);
+        when(userRepository.existsByEmail("existing@example.com")).thenReturn(true);
+
+        UserAlreadyExistsException exception = assertThrows(UserAlreadyExistsException.class, () ->
+                userService.registerUser(request)
+        );
+
+        assertEquals("Email already in use", exception.getMessage());
         verify(userRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## Summary
- normalize emails before checking for duplicates
- handle duplicate user errors in the API controller
- update unit tests for new exception type and add coverage for email normalization

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6842a5f701d0832fb33dc30ef029e6a2