### PR TITLE
Add set-answer question type (fixed-size solutions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Quizle is a self-hosted quiz platform inspired by daily puzzle games like **Word
 ## Features
 
 * **User registration** – register new players using a simple form.
+* **Question practice APIs** – create and answer basic questions and fixed-size set-answer questions such as “Name the layers of the OSI model.”
 * **Planned:** create quizzes with multiple question types and track results.
 
 The database schema already includes tables for quizzes, questions and answers to support future development.

--- a/api/src/main/java/com/blanchaert/quizle/controller/ApiExceptionHandler.java
+++ b/api/src/main/java/com/blanchaert/quizle/controller/ApiExceptionHandler.java
@@ -15,6 +15,11 @@ public class ApiExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(ex.getMessage());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException ex) {
         return ResponseEntity.badRequest().body("Request validation failed");

--- a/api/src/main/java/com/blanchaert/quizle/controller/question/SetAnswerQuestionController.java
+++ b/api/src/main/java/com/blanchaert/quizle/controller/question/SetAnswerQuestionController.java
@@ -1,0 +1,52 @@
+package com.blanchaert.quizle.controller.question;
+
+import com.blanchaert.quizle.domain.question.SetAnswerQuestionService;
+import com.blanchaert.quizle.dto.question.CreateSetAnswerQuestionRequest;
+import com.blanchaert.quizle.dto.question.SetAnswerQuestionAttemptResponse;
+import com.blanchaert.quizle.dto.question.SetAnswerQuestionResponse;
+import com.blanchaert.quizle.dto.question.SolveSetAnswerQuestionRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/set-answer-questions")
+public class SetAnswerQuestionController {
+    private final SetAnswerQuestionService questionService;
+
+    @PostMapping
+    public ResponseEntity<SetAnswerQuestionResponse> createQuestion(
+            @Valid @RequestBody CreateSetAnswerQuestionRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(questionService.createQuestion(request));
+    }
+
+    @GetMapping
+    public List<SetAnswerQuestionResponse> listQuestions() {
+        return questionService.listQuestions();
+    }
+
+    @GetMapping("/{questionId}")
+    public SetAnswerQuestionResponse getQuestion(@PathVariable UUID questionId) {
+        return questionService.getQuestion(questionId);
+    }
+
+    @PostMapping("/{questionId}/attempts")
+    public SetAnswerQuestionAttemptResponse solveQuestion(
+            @PathVariable UUID questionId,
+            @Valid @RequestBody SolveSetAnswerQuestionRequest request
+    ) {
+        return questionService.solveQuestion(questionId, request);
+    }
+}

--- a/api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestion.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestion.java
@@ -1,0 +1,53 @@
+package com.blanchaert.quizle.domain.question;
+
+import com.blanchaert.quizle.domain.user.User;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "set_answer_questions")
+@Data
+public class SetAnswerQuestion {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @Column(name = "question_text", nullable = false)
+    private String question;
+
+    @Column(name = "required_answers", nullable = false)
+    private int requiredAnswers;
+
+    @ElementCollection
+    @CollectionTable(
+            name = "set_answer_question_solutions",
+            joinColumns = @JoinColumn(name = "question_id")
+    )
+    @OrderColumn(name = "solution_order")
+    @Column(name = "answer_text", nullable = false)
+    private List<String> answers = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+}

--- a/api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionAttempt.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionAttempt.java
@@ -1,0 +1,57 @@
+package com.blanchaert.quizle.domain.question;
+
+import com.blanchaert.quizle.domain.user.User;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "set_answer_question_attempts")
+@Data
+public class SetAnswerQuestionAttempt {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "question_id", nullable = false)
+    private SetAnswerQuestion question;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ElementCollection
+    @CollectionTable(
+            name = "set_answer_question_attempt_answers",
+            joinColumns = @JoinColumn(name = "attempt_id")
+    )
+    @OrderColumn(name = "answer_order")
+    @Column(name = "answer_text", nullable = false)
+    private List<String> submittedAnswers = new ArrayList<>();
+
+    @Column(name = "correct_answers", nullable = false)
+    private int correctAnswers;
+
+    @Column(name = "is_correct", nullable = false)
+    private boolean correct;
+
+    @Column(name = "attempted_at", nullable = false)
+    private Instant attemptedAt = Instant.now();
+}

--- a/api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionAttemptRepository.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionAttemptRepository.java
@@ -1,0 +1,8 @@
+package com.blanchaert.quizle.domain.question;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SetAnswerQuestionAttemptRepository extends JpaRepository<SetAnswerQuestionAttempt, UUID> {
+}

--- a/api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionRepository.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionRepository.java
@@ -1,0 +1,8 @@
+package com.blanchaert.quizle.domain.question;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SetAnswerQuestionRepository extends JpaRepository<SetAnswerQuestion, UUID> {
+}

--- a/api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionService.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionService.java
@@ -1,0 +1,147 @@
+package com.blanchaert.quizle.domain.question;
+
+import com.blanchaert.quizle.domain.user.User;
+import com.blanchaert.quizle.domain.user.UserRepository;
+import com.blanchaert.quizle.dto.question.CreateSetAnswerQuestionRequest;
+import com.blanchaert.quizle.dto.question.SetAnswerQuestionAttemptResponse;
+import com.blanchaert.quizle.dto.question.SetAnswerQuestionResponse;
+import com.blanchaert.quizle.dto.question.SolveSetAnswerQuestionRequest;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class SetAnswerQuestionService {
+    private final SetAnswerQuestionRepository questionRepository;
+    private final SetAnswerQuestionAttemptRepository attemptRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public SetAnswerQuestionResponse createQuestion(CreateSetAnswerQuestionRequest request) {
+        User user = currentUser();
+        List<String> answers = trimmedDistinct(request.getAnswers());
+
+        if (request.getRequiredAnswers() > answers.size()) {
+            throw new IllegalArgumentException("Required answers cannot exceed available answers");
+        }
+
+        SetAnswerQuestion question = new SetAnswerQuestion();
+        question.setQuestion(request.getQuestion().trim());
+        question.setRequiredAnswers(request.getRequiredAnswers());
+        question.setAnswers(answers);
+        question.setCreatedBy(user);
+
+        return toResponse(questionRepository.save(question));
+    }
+
+    @Transactional(readOnly = true)
+    public List<SetAnswerQuestionResponse> listQuestions() {
+        return questionRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public SetAnswerQuestionResponse getQuestion(UUID questionId) {
+        return questionRepository.findById(questionId)
+                .map(this::toResponse)
+                .orElseThrow(() -> new EntityNotFoundException("Question not found"));
+    }
+
+    @Transactional
+    public SetAnswerQuestionAttemptResponse solveQuestion(UUID questionId, SolveSetAnswerQuestionRequest request) {
+        User user = currentUser();
+        SetAnswerQuestion question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new EntityNotFoundException("Question not found"));
+
+        List<String> submittedAnswers = trimmedDistinct(request.getAnswers());
+        if (submittedAnswers.size() != question.getRequiredAnswers()) {
+            throw new IllegalArgumentException("Submit exactly " + question.getRequiredAnswers() + " answers");
+        }
+
+        int correctAnswers = countCorrectAnswers(question.getAnswers(), submittedAnswers);
+
+        SetAnswerQuestionAttempt attempt = new SetAnswerQuestionAttempt();
+        attempt.setQuestion(question);
+        attempt.setUser(user);
+        attempt.setSubmittedAnswers(submittedAnswers);
+        attempt.setCorrectAnswers(correctAnswers);
+        attempt.setCorrect(correctAnswers == question.getRequiredAnswers());
+
+        return toResponse(attemptRepository.save(attempt));
+    }
+
+    private User currentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new IllegalStateException("A logged-in user is required");
+        }
+
+        return userRepository.findByUsername(authentication.getName())
+                .orElseThrow(() -> new EntityNotFoundException("Authenticated user not found"));
+    }
+
+    private int countCorrectAnswers(List<String> expectedAnswers, List<String> submittedAnswers) {
+        Set<String> expected = expectedAnswers.stream()
+                .map(this::normalize)
+                .collect(Collectors.toSet());
+
+        return (int) submittedAnswers.stream()
+                .map(this::normalize)
+                .filter(expected::contains)
+                .count();
+    }
+
+    private List<String> trimmedDistinct(List<String> values) {
+        return values.stream()
+                .map(String::trim)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toMap(
+                                this::normalize,
+                                Function.identity(),
+                                (first, duplicate) -> first,
+                                LinkedHashMap::new
+                        ),
+                        map -> List.copyOf(map.values())
+                ));
+    }
+
+    private String normalize(String value) {
+        return value.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private SetAnswerQuestionResponse toResponse(SetAnswerQuestion question) {
+        return new SetAnswerQuestionResponse(
+                question.getId(),
+                question.getQuestion(),
+                question.getRequiredAnswers(),
+                question.getAnswers().size(),
+                question.getCreatedBy().getUsername(),
+                question.getCreatedAt()
+        );
+    }
+
+    private SetAnswerQuestionAttemptResponse toResponse(SetAnswerQuestionAttempt attempt) {
+        return new SetAnswerQuestionAttemptResponse(
+                attempt.getId(),
+                attempt.getQuestion().getId(),
+                List.copyOf(attempt.getSubmittedAnswers()),
+                attempt.getCorrectAnswers(),
+                attempt.getQuestion().getRequiredAnswers(),
+                attempt.isCorrect(),
+                attempt.getAttemptedAt()
+        );
+    }
+}

--- a/api/src/main/java/com/blanchaert/quizle/dto/question/CreateSetAnswerQuestionRequest.java
+++ b/api/src/main/java/com/blanchaert/quizle/dto/question/CreateSetAnswerQuestionRequest.java
@@ -1,0 +1,20 @@
+package com.blanchaert.quizle.dto.question;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CreateSetAnswerQuestionRequest {
+    @NotBlank
+    private String question;
+
+    @Min(1)
+    private int requiredAnswers;
+
+    @NotEmpty
+    private List<@NotBlank String> answers;
+}

--- a/api/src/main/java/com/blanchaert/quizle/dto/question/SetAnswerQuestionAttemptResponse.java
+++ b/api/src/main/java/com/blanchaert/quizle/dto/question/SetAnswerQuestionAttemptResponse.java
@@ -1,0 +1,16 @@
+package com.blanchaert.quizle.dto.question;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record SetAnswerQuestionAttemptResponse(
+        UUID attemptId,
+        UUID questionId,
+        List<String> submittedAnswers,
+        int correctAnswers,
+        int requiredAnswers,
+        boolean correct,
+        Instant attemptedAt
+) {
+}

--- a/api/src/main/java/com/blanchaert/quizle/dto/question/SetAnswerQuestionResponse.java
+++ b/api/src/main/java/com/blanchaert/quizle/dto/question/SetAnswerQuestionResponse.java
@@ -1,0 +1,14 @@
+package com.blanchaert.quizle.dto.question;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record SetAnswerQuestionResponse(
+        UUID id,
+        String question,
+        int requiredAnswers,
+        int availableAnswers,
+        String createdBy,
+        Instant createdAt
+) {
+}

--- a/api/src/main/java/com/blanchaert/quizle/dto/question/SolveSetAnswerQuestionRequest.java
+++ b/api/src/main/java/com/blanchaert/quizle/dto/question/SolveSetAnswerQuestionRequest.java
@@ -1,0 +1,13 @@
+package com.blanchaert.quizle.dto.question;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SolveSetAnswerQuestionRequest {
+    @NotEmpty
+    private List<@NotBlank String> answers;
+}

--- a/api/src/main/resources/db/migration/cockroachdb/V3__init_set_answer_questions.sql
+++ b/api/src/main/resources/db/migration/cockroachdb/V3__init_set_answer_questions.sql
@@ -1,0 +1,39 @@
+CREATE TABLE set_answer_questions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_by UUID NOT NULL,
+    question_text TEXT NOT NULL,
+    required_answers INT NOT NULL CHECK (required_answers > 0),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_set_answer_questions_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE set_answer_question_solutions (
+    question_id UUID NOT NULL,
+    solution_order INT NOT NULL,
+    answer_text TEXT NOT NULL,
+    PRIMARY KEY (question_id, solution_order),
+    CONSTRAINT fk_set_answer_question_solutions_question_id FOREIGN KEY (question_id) REFERENCES set_answer_questions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE set_answer_question_attempts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    question_id UUID NOT NULL,
+    user_id UUID NOT NULL,
+    correct_answers INT NOT NULL DEFAULT 0,
+    is_correct BOOLEAN NOT NULL,
+    attempted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_set_answer_question_attempts_question_id FOREIGN KEY (question_id) REFERENCES set_answer_questions(id) ON DELETE CASCADE,
+    CONSTRAINT fk_set_answer_question_attempts_user_id FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE set_answer_question_attempt_answers (
+    attempt_id UUID NOT NULL,
+    answer_order INT NOT NULL,
+    answer_text TEXT NOT NULL,
+    PRIMARY KEY (attempt_id, answer_order),
+    CONSTRAINT fk_set_answer_question_attempt_answers_attempt_id FOREIGN KEY (attempt_id) REFERENCES set_answer_question_attempts(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_set_answer_questions_created_by ON set_answer_questions (created_by);
+CREATE INDEX idx_set_answer_question_attempts_question_id ON set_answer_question_attempts (question_id);
+CREATE INDEX idx_set_answer_question_attempts_user_id ON set_answer_question_attempts (user_id);

--- a/api/src/main/resources/db/migration/mariadb/V3__init_set_answer_questions.sql
+++ b/api/src/main/resources/db/migration/mariadb/V3__init_set_answer_questions.sql
@@ -1,0 +1,39 @@
+CREATE TABLE set_answer_questions (
+    id BINARY(16) PRIMARY KEY DEFAULT (uuid_v4()),
+    created_by BINARY(16) NOT NULL,
+    question_text TEXT NOT NULL,
+    required_answers INT NOT NULL CHECK (required_answers > 0),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_set_answer_questions_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE set_answer_question_solutions (
+    question_id BINARY(16) NOT NULL,
+    solution_order INT NOT NULL,
+    answer_text TEXT NOT NULL,
+    PRIMARY KEY (question_id, solution_order),
+    CONSTRAINT fk_set_answer_question_solutions_question_id FOREIGN KEY (question_id) REFERENCES set_answer_questions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE set_answer_question_attempts (
+    id BINARY(16) PRIMARY KEY DEFAULT (uuid_v4()),
+    question_id BINARY(16) NOT NULL,
+    user_id BINARY(16) NOT NULL,
+    correct_answers INT NOT NULL DEFAULT 0,
+    is_correct BOOLEAN NOT NULL,
+    attempted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_set_answer_question_attempts_question_id FOREIGN KEY (question_id) REFERENCES set_answer_questions(id) ON DELETE CASCADE,
+    CONSTRAINT fk_set_answer_question_attempts_user_id FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE set_answer_question_attempt_answers (
+    attempt_id BINARY(16) NOT NULL,
+    answer_order INT NOT NULL,
+    answer_text TEXT NOT NULL,
+    PRIMARY KEY (attempt_id, answer_order),
+    CONSTRAINT fk_set_answer_question_attempt_answers_attempt_id FOREIGN KEY (attempt_id) REFERENCES set_answer_question_attempts(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_set_answer_questions_created_by ON set_answer_questions (created_by);
+CREATE INDEX idx_set_answer_question_attempts_question_id ON set_answer_question_attempts (question_id);
+CREATE INDEX idx_set_answer_question_attempts_user_id ON set_answer_question_attempts (user_id);

--- a/api/src/main/resources/db/migration/postgres/V5__init_set_answer_questions.sql
+++ b/api/src/main/resources/db/migration/postgres/V5__init_set_answer_questions.sql
@@ -1,0 +1,34 @@
+CREATE TABLE set_answer_questions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  question_text TEXT NOT NULL,
+  required_answers INT NOT NULL CHECK (required_answers > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE set_answer_question_solutions (
+  question_id UUID NOT NULL REFERENCES set_answer_questions(id) ON DELETE CASCADE,
+  solution_order INT NOT NULL,
+  answer_text TEXT NOT NULL,
+  PRIMARY KEY (question_id, solution_order)
+);
+
+CREATE TABLE set_answer_question_attempts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  question_id UUID NOT NULL REFERENCES set_answer_questions(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  correct_answers INT NOT NULL DEFAULT 0,
+  is_correct BOOLEAN NOT NULL,
+  attempted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE set_answer_question_attempt_answers (
+  attempt_id UUID NOT NULL REFERENCES set_answer_question_attempts(id) ON DELETE CASCADE,
+  answer_order INT NOT NULL,
+  answer_text TEXT NOT NULL,
+  PRIMARY KEY (attempt_id, answer_order)
+);
+
+CREATE INDEX idx_set_answer_questions_created_by ON set_answer_questions (created_by);
+CREATE INDEX idx_set_answer_question_attempts_question_id ON set_answer_question_attempts (question_id);
+CREATE INDEX idx_set_answer_question_attempts_user_id ON set_answer_question_attempts (user_id);

--- a/api/src/test/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionServiceUnitTest.java
+++ b/api/src/test/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionServiceUnitTest.java
@@ -1,0 +1,183 @@
+package com.blanchaert.quizle.domain.question;
+
+import com.blanchaert.quizle.domain.user.Role;
+import com.blanchaert.quizle.domain.user.User;
+import com.blanchaert.quizle.domain.user.UserRepository;
+import com.blanchaert.quizle.dto.question.CreateSetAnswerQuestionRequest;
+import com.blanchaert.quizle.dto.question.SolveSetAnswerQuestionRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Tag("unit")
+class SetAnswerQuestionServiceUnitTest {
+
+    private SetAnswerQuestionRepository questionRepository;
+    private SetAnswerQuestionAttemptRepository attemptRepository;
+    private UserRepository userRepository;
+    private SetAnswerQuestionService questionService;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        questionRepository = mock(SetAnswerQuestionRepository.class);
+        attemptRepository = mock(SetAnswerQuestionAttemptRepository.class);
+        userRepository = mock(UserRepository.class);
+        questionService = new SetAnswerQuestionService(questionRepository, attemptRepository, userRepository);
+
+        user = new User();
+        user.setId(UUID.randomUUID());
+        user.setUsername("learner");
+        user.setEmail("learner@example.com");
+        user.setPasswordHash("hash");
+        user.setRole(Role.USER);
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("learner", "password", List.of())
+        );
+        when(userRepository.findByUsername("learner")).thenReturn(Optional.of(user));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createQuestion_savesQuestionWithRequiredAnswerCount() {
+        CreateSetAnswerQuestionRequest request = new CreateSetAnswerQuestionRequest();
+        request.setQuestion(" Name the layers of the OSI model ");
+        request.setRequiredAnswers(7);
+        request.setAnswers(List.of(
+                " Physical ",
+                "Data Link",
+                "Network",
+                "Transport",
+                "Session",
+                "Presentation",
+                "Application"
+        ));
+        when(questionRepository.save(any(SetAnswerQuestion.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        questionService.createQuestion(request);
+
+        ArgumentCaptor<SetAnswerQuestion> questionCaptor = ArgumentCaptor.forClass(SetAnswerQuestion.class);
+        verify(questionRepository).save(questionCaptor.capture());
+        SetAnswerQuestion savedQuestion = questionCaptor.getValue();
+        assertEquals("Name the layers of the OSI model", savedQuestion.getQuestion());
+        assertEquals(7, savedQuestion.getRequiredAnswers());
+        assertEquals(List.of(
+                "Physical",
+                "Data Link",
+                "Network",
+                "Transport",
+                "Session",
+                "Presentation",
+                "Application"
+        ), savedQuestion.getAnswers());
+        assertEquals(user, savedQuestion.getCreatedBy());
+    }
+
+    @Test
+    void createQuestion_rejectsRequiredCountGreaterThanAvailableAnswers() {
+        CreateSetAnswerQuestionRequest request = new CreateSetAnswerQuestionRequest();
+        request.setQuestion("Name three primary colors");
+        request.setRequiredAnswers(4);
+        request.setAnswers(List.of("red", "blue", "yellow"));
+
+        assertThrows(IllegalArgumentException.class, () -> questionService.createQuestion(request));
+    }
+
+    @Test
+    void solveQuestion_storesAttemptAndMarksAllRequiredAnswersCorrect() {
+        UUID questionId = UUID.randomUUID();
+        SetAnswerQuestion question = new SetAnswerQuestion();
+        question.setId(questionId);
+        question.setQuestion("Name the layers of the OSI model");
+        question.setRequiredAnswers(7);
+        question.setAnswers(List.of(
+                "Physical",
+                "Data Link",
+                "Network",
+                "Transport",
+                "Session",
+                "Presentation",
+                "Application"
+        ));
+        question.setCreatedBy(user);
+        when(questionRepository.findById(questionId)).thenReturn(Optional.of(question));
+        when(attemptRepository.save(any(SetAnswerQuestionAttempt.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SolveSetAnswerQuestionRequest request = new SolveSetAnswerQuestionRequest();
+        request.setAnswers(List.of(
+                "physical",
+                " data link ",
+                "NETWORK",
+                "Transport",
+                "Session",
+                "Presentation",
+                "Application"
+        ));
+
+        var response = questionService.solveQuestion(questionId, request);
+
+        ArgumentCaptor<SetAnswerQuestionAttempt> attemptCaptor = ArgumentCaptor.forClass(SetAnswerQuestionAttempt.class);
+        verify(attemptRepository).save(attemptCaptor.capture());
+        SetAnswerQuestionAttempt savedAttempt = attemptCaptor.getValue();
+        assertEquals(question, savedAttempt.getQuestion());
+        assertEquals(user, savedAttempt.getUser());
+        assertEquals(7, savedAttempt.getCorrectAnswers());
+        assertTrue(savedAttempt.isCorrect());
+        assertEquals(List.of(
+                "physical",
+                "data link",
+                "NETWORK",
+                "Transport",
+                "Session",
+                "Presentation",
+                "Application"
+        ), savedAttempt.getSubmittedAnswers());
+        assertTrue(response.correct());
+    }
+
+    @Test
+    void solveQuestion_requiresExactlyTheConfiguredNumberOfAnswers() {
+        UUID questionId = UUID.randomUUID();
+        SetAnswerQuestion question = new SetAnswerQuestion();
+        question.setId(questionId);
+        question.setQuestion("Name the layers of the OSI model");
+        question.setRequiredAnswers(7);
+        question.setAnswers(List.of(
+                "Physical",
+                "Data Link",
+                "Network",
+                "Transport",
+                "Session",
+                "Presentation",
+                "Application"
+        ));
+        question.setCreatedBy(user);
+        when(questionRepository.findById(questionId)).thenReturn(Optional.of(question));
+
+        SolveSetAnswerQuestionRequest request = new SolveSetAnswerQuestionRequest();
+        request.setAnswers(List.of("Physical", "Data Link"));
+
+        assertThrows(IllegalArgumentException.class, () -> questionService.solveQuestion(questionId, request));
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a new question type where a solver must submit a fixed number of distinct answers (e.g. “Name the layers of the OSI model”).
- Persist both the canonical solutions and per-attempt submitted answers and scoring so the API can create/list/get questions and record scored attempts.
- Add DB migrations so the new domain objects can be stored on PostgreSQL, CockroachDB and MariaDB.

### Description
- Add domain entities and repositories: `SetAnswerQuestion`, `SetAnswerQuestionAttempt`, `SetAnswerQuestionRepository`, and `SetAnswerQuestionAttemptRepository` to store questions, accepted solutions, attempts and submitted answers. (`api/src/main/java/com/blanchaert/quizle/domain/question/*`)
- Implement service logic in `SetAnswerQuestionService` that trims, normalizes and de-duplicates answers, enforces that exactly the configured number of answers is submitted, counts correct matches case-insensitively, and persists attempts. (`api/src/main/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionService.java`)
- Add a REST controller exposing create/list/get/attempt endpoints at `/api/set-answer-questions`. (`api/src/main/java/com/blanchaert/quizle/controller/question/SetAnswerQuestionController.java`)
- Add request/response DTOs with validation: `CreateSetAnswerQuestionRequest`, `SolveSetAnswerQuestionRequest`, `SetAnswerQuestionResponse`, and `SetAnswerQuestionAttemptResponse`. (`api/src/main/java/com/blanchaert/quizle/dto/question/*`)
- Add Flyway migrations for PostgreSQL, CockroachDB and MariaDB to create tables for questions, ordered solutions, attempts and submitted answers. (`api/src/main/resources/db/migration/*/V*_init_set_answer_questions.sql`)
- Map domain `IllegalArgumentException`s to HTTP 400 by adding a handler in `ApiExceptionHandler`. (`api/src/main/java/com/blanchaert/quizle/controller/ApiExceptionHandler.java`)
- Add unit tests covering creating questions, rejecting invalid configurations, solving with normalized answers, and enforcing exact answer counts. (`api/src/test/java/com/blanchaert/quizle/domain/question/SetAnswerQuestionServiceUnitTest.java`)
- Document the new capability in the `README.md`.

### Testing
- Unit tests were added for the `SetAnswerQuestionService` (`SetAnswerQuestionServiceUnitTest`).
- Attempted to run tests in this environment with `./mvnw test`, but the Maven wrapper could not download the Maven distribution (network artifact fetch failed), so the run failed. (failed)
- `mvn test` also failed due to inability to resolve the Spring Boot parent POM from Maven Central (HTTP 403), and `mvn -o test` failed because required dependencies are not available in the local cache, so automated tests could not be executed here. (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a070ea30020832f874165e6c33cea6d)