### PR TITLE
Add question set quiz APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Quizle is a self-hosted quiz platform inspired by daily puzzle games like **Word
 
 * **User registration** – register new players using a simple form.
 * **Question practice APIs** – create and answer basic questions and fixed-size set-answer questions such as “Name the layers of the OSI model.”
-* **Planned:** create quizzes with multiple question types and track results.
+* **Question set APIs** – create quiz-style sets that combine multiple ordered questions, such as a basic OSI layer-number question followed by a complete-list OSI layers question.
+* **Planned:** track quiz-style set results across multiple questions.
 
-The database schema already includes tables for quizzes, questions and answers to support future development.
+The database schema includes tables for standalone questions, question sets and existing quiz/answer groundwork for future attempt tracking.
 
 ## Technologies Used
 

--- a/api/src/main/java/com/blanchaert/quizle/controller/quiz/QuestionSetController.java
+++ b/api/src/main/java/com/blanchaert/quizle/controller/quiz/QuestionSetController.java
@@ -1,0 +1,40 @@
+package com.blanchaert.quizle.controller.quiz;
+
+import com.blanchaert.quizle.domain.quiz.QuestionSetService;
+import com.blanchaert.quizle.dto.quiz.CreateQuestionSetRequest;
+import com.blanchaert.quizle.dto.quiz.QuestionSetResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/question-sets")
+public class QuestionSetController {
+    private final QuestionSetService questionSetService;
+
+    @PostMapping
+    public ResponseEntity<QuestionSetResponse> createQuestionSet(@Valid @RequestBody CreateQuestionSetRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(questionSetService.createQuestionSet(request));
+    }
+
+    @GetMapping
+    public List<QuestionSetResponse> listQuestionSets() {
+        return questionSetService.listQuestionSets();
+    }
+
+    @GetMapping("/{questionSetId}")
+    public QuestionSetResponse getQuestionSet(@PathVariable UUID questionSetId) {
+        return questionSetService.getQuestionSet(questionSetId);
+    }
+}

--- a/api/src/main/java/com/blanchaert/quizle/domain/quiz/QuestionSet.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/quiz/QuestionSet.java
@@ -1,0 +1,57 @@
+package com.blanchaert.quizle.domain.quiz;
+
+import com.blanchaert.quizle.domain.user.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "question_sets")
+@Data
+public class QuestionSet {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column
+    private String description;
+
+    @OneToMany(mappedBy = "questionSet", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("position ASC")
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private List<QuestionSetItem> questions = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
+    public void addQuestion(QuestionSetItem item) {
+        item.setQuestionSet(this);
+        questions.add(item);
+    }
+}

--- a/api/src/main/java/com/blanchaert/quizle/domain/quiz/QuestionSetItem.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/quiz/QuestionSetItem.java
@@ -1,0 +1,51 @@
+package com.blanchaert.quizle.domain.quiz;
+
+import com.blanchaert.quizle.domain.question.BasicQuestion;
+import com.blanchaert.quizle.domain.question.SetAnswerQuestion;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "question_set_items")
+@Data
+public class QuestionSetItem {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "question_set_id", nullable = false)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private QuestionSet questionSet;
+
+    @Column(nullable = false)
+    private int position;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "question_type", nullable = false)
+    private QuestionSetQuestionType questionType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "basic_question_id")
+    private BasicQuestion basicQuestion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "set_answer_question_id")
+    private SetAnswerQuestion setAnswerQuestion;
+}

--- a/api/src/main/java/com/blanchaert/quizle/domain/quiz/QuestionSetQuestionType.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/quiz/QuestionSetQuestionType.java
@@ -1,0 +1,6 @@
+package com.blanchaert.quizle.domain.quiz;
+
+public enum QuestionSetQuestionType {
+    BASIC,
+    SET_ANSWER
+}

--- a/api/src/main/java/com/blanchaert/quizle/domain/quiz/QuestionSetRepository.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/quiz/QuestionSetRepository.java
@@ -1,0 +1,8 @@
+package com.blanchaert.quizle.domain.quiz;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface QuestionSetRepository extends JpaRepository<QuestionSet, UUID> {
+}

--- a/api/src/main/java/com/blanchaert/quizle/domain/quiz/QuestionSetService.java
+++ b/api/src/main/java/com/blanchaert/quizle/domain/quiz/QuestionSetService.java
@@ -1,0 +1,187 @@
+package com.blanchaert.quizle.domain.quiz;
+
+import com.blanchaert.quizle.domain.question.BasicQuestion;
+import com.blanchaert.quizle.domain.question.BasicQuestionRepository;
+import com.blanchaert.quizle.domain.question.SetAnswerQuestion;
+import com.blanchaert.quizle.domain.question.SetAnswerQuestionRepository;
+import com.blanchaert.quizle.domain.user.User;
+import com.blanchaert.quizle.domain.user.UserRepository;
+import com.blanchaert.quizle.dto.quiz.CreateQuestionSetQuestionRequest;
+import com.blanchaert.quizle.dto.quiz.CreateQuestionSetRequest;
+import com.blanchaert.quizle.dto.quiz.QuestionSetQuestionResponse;
+import com.blanchaert.quizle.dto.quiz.QuestionSetResponse;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class QuestionSetService {
+    private final QuestionSetRepository questionSetRepository;
+    private final BasicQuestionRepository basicQuestionRepository;
+    private final SetAnswerQuestionRepository setAnswerQuestionRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public QuestionSetResponse createQuestionSet(CreateQuestionSetRequest request) {
+        User user = currentUser();
+
+        QuestionSet questionSet = new QuestionSet();
+        questionSet.setTitle(request.getTitle().trim());
+        questionSet.setDescription(trimToNull(request.getDescription()));
+        questionSet.setCreatedBy(user);
+
+        for (int index = 0; index < request.getQuestions().size(); index++) {
+            questionSet.addQuestion(createItem(user, request.getQuestions().get(index), index + 1));
+        }
+
+        return toResponse(questionSetRepository.save(questionSet));
+    }
+
+    @Transactional(readOnly = true)
+    public List<QuestionSetResponse> listQuestionSets() {
+        return questionSetRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public QuestionSetResponse getQuestionSet(UUID questionSetId) {
+        return questionSetRepository.findById(questionSetId)
+                .map(this::toResponse)
+                .orElseThrow(() -> new EntityNotFoundException("Question set not found"));
+    }
+
+    private QuestionSetItem createItem(User user, CreateQuestionSetQuestionRequest request, int position) {
+        QuestionSetItem item = new QuestionSetItem();
+        item.setPosition(position);
+        item.setQuestionType(request.getType());
+
+        switch (request.getType()) {
+            case BASIC -> item.setBasicQuestion(createBasicQuestion(user, request));
+            case SET_ANSWER -> item.setSetAnswerQuestion(createSetAnswerQuestion(user, request));
+            default -> throw new IllegalArgumentException("Unsupported question type");
+        }
+
+        return item;
+    }
+
+    private BasicQuestion createBasicQuestion(User user, CreateQuestionSetQuestionRequest request) {
+        if (request.getAnswer() == null || request.getAnswer().isBlank()) {
+            throw new IllegalArgumentException("Basic questions require an answer");
+        }
+
+        BasicQuestion question = new BasicQuestion();
+        question.setQuestion(request.getQuestion().trim());
+        question.setAnswer(request.getAnswer().trim());
+        question.setCreatedBy(user);
+        return basicQuestionRepository.save(question);
+    }
+
+    private SetAnswerQuestion createSetAnswerQuestion(User user, CreateQuestionSetQuestionRequest request) {
+        if (request.getAnswers() == null || request.getAnswers().isEmpty()) {
+            throw new IllegalArgumentException("Set-answer questions require answers");
+        }
+
+        List<String> answers = trimmedDistinct(request.getAnswers());
+        if (answers.isEmpty()) {
+            throw new IllegalArgumentException("Set-answer questions require answers");
+        }
+        if (request.getRequiredAnswers() < 1) {
+            throw new IllegalArgumentException("Set-answer questions require at least one required answer");
+        }
+        if (request.getRequiredAnswers() > answers.size()) {
+            throw new IllegalArgumentException("Required answers cannot exceed available answers");
+        }
+
+        SetAnswerQuestion question = new SetAnswerQuestion();
+        question.setQuestion(request.getQuestion().trim());
+        question.setRequiredAnswers(request.getRequiredAnswers());
+        question.setAnswers(answers);
+        question.setCreatedBy(user);
+        return setAnswerQuestionRepository.save(question);
+    }
+
+    private User currentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new IllegalStateException("A logged-in user is required");
+        }
+
+        return userRepository.findByUsername(authentication.getName())
+                .orElseThrow(() -> new EntityNotFoundException("Authenticated user not found"));
+    }
+
+    private List<String> trimmedDistinct(List<String> values) {
+        return values.stream()
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toMap(
+                                this::normalize,
+                                Function.identity(),
+                                (first, duplicate) -> first,
+                                LinkedHashMap::new
+                        ),
+                        map -> List.copyOf(map.values())
+                ));
+    }
+
+    private String normalize(String value) {
+        return value.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String trimToNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private QuestionSetResponse toResponse(QuestionSet questionSet) {
+        return new QuestionSetResponse(
+                questionSet.getId(),
+                questionSet.getTitle(),
+                questionSet.getDescription(),
+                questionSet.getCreatedBy().getUsername(),
+                questionSet.getCreatedAt(),
+                questionSet.getQuestions().stream()
+                        .map(this::toQuestionResponse)
+                        .toList()
+        );
+    }
+
+    private QuestionSetQuestionResponse toQuestionResponse(QuestionSetItem item) {
+        if (item.getQuestionType() == QuestionSetQuestionType.BASIC) {
+            BasicQuestion question = item.getBasicQuestion();
+            return new QuestionSetQuestionResponse(
+                    item.getPosition(),
+                    item.getQuestionType(),
+                    question.getId(),
+                    question.getQuestion(),
+                    null,
+                    null
+            );
+        }
+
+        SetAnswerQuestion question = item.getSetAnswerQuestion();
+        return new QuestionSetQuestionResponse(
+                item.getPosition(),
+                item.getQuestionType(),
+                question.getId(),
+                question.getQuestion(),
+                question.getRequiredAnswers(),
+                question.getAnswers().size()
+        );
+    }
+}

--- a/api/src/main/java/com/blanchaert/quizle/dto/quiz/CreateQuestionSetQuestionRequest.java
+++ b/api/src/main/java/com/blanchaert/quizle/dto/quiz/CreateQuestionSetQuestionRequest.java
@@ -1,0 +1,25 @@
+package com.blanchaert.quizle.dto.quiz;
+
+import com.blanchaert.quizle.domain.quiz.QuestionSetQuestionType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CreateQuestionSetQuestionRequest {
+    @NotNull
+    private QuestionSetQuestionType type;
+
+    @NotBlank
+    private String question;
+
+    private String answer;
+
+    @Min(1)
+    private int requiredAnswers;
+
+    private List<@NotBlank String> answers;
+}

--- a/api/src/main/java/com/blanchaert/quizle/dto/quiz/CreateQuestionSetRequest.java
+++ b/api/src/main/java/com/blanchaert/quizle/dto/quiz/CreateQuestionSetRequest.java
@@ -1,0 +1,19 @@
+package com.blanchaert.quizle.dto.quiz;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CreateQuestionSetRequest {
+    @NotBlank
+    private String title;
+
+    private String description;
+
+    @NotEmpty
+    private List<@Valid CreateQuestionSetQuestionRequest> questions;
+}

--- a/api/src/main/java/com/blanchaert/quizle/dto/quiz/QuestionSetQuestionResponse.java
+++ b/api/src/main/java/com/blanchaert/quizle/dto/quiz/QuestionSetQuestionResponse.java
@@ -1,0 +1,15 @@
+package com.blanchaert.quizle.dto.quiz;
+
+import com.blanchaert.quizle.domain.quiz.QuestionSetQuestionType;
+
+import java.util.UUID;
+
+public record QuestionSetQuestionResponse(
+        int position,
+        QuestionSetQuestionType type,
+        UUID questionId,
+        String question,
+        Integer requiredAnswers,
+        Integer availableAnswers
+) {
+}

--- a/api/src/main/java/com/blanchaert/quizle/dto/quiz/QuestionSetResponse.java
+++ b/api/src/main/java/com/blanchaert/quizle/dto/quiz/QuestionSetResponse.java
@@ -1,0 +1,15 @@
+package com.blanchaert.quizle.dto.quiz;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record QuestionSetResponse(
+        UUID id,
+        String title,
+        String description,
+        String createdBy,
+        Instant createdAt,
+        List<QuestionSetQuestionResponse> questions
+) {
+}

--- a/api/src/main/resources/db/migration/cockroachdb/V4__init_question_sets.sql
+++ b/api/src/main/resources/db/migration/cockroachdb/V4__init_question_sets.sql
@@ -1,0 +1,31 @@
+CREATE TABLE question_sets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_by UUID NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_question_sets_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE question_set_items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    question_set_id UUID NOT NULL,
+    position INT NOT NULL CHECK (position > 0),
+    question_type TEXT NOT NULL CHECK (question_type IN ('BASIC', 'SET_ANSWER')),
+    basic_question_id UUID,
+    set_answer_question_id UUID,
+    CONSTRAINT fk_question_set_items_question_set_id FOREIGN KEY (question_set_id) REFERENCES question_sets(id) ON DELETE CASCADE,
+    CONSTRAINT fk_question_set_items_basic_question_id FOREIGN KEY (basic_question_id) REFERENCES basic_questions(id) ON DELETE CASCADE,
+    CONSTRAINT fk_question_set_items_set_answer_question_id FOREIGN KEY (set_answer_question_id) REFERENCES set_answer_questions(id) ON DELETE CASCADE,
+    CONSTRAINT uq_question_set_items_position UNIQUE (question_set_id, position),
+    CONSTRAINT chk_question_set_items_question_reference CHECK (
+        (question_type = 'BASIC' AND basic_question_id IS NOT NULL AND set_answer_question_id IS NULL)
+        OR
+        (question_type = 'SET_ANSWER' AND set_answer_question_id IS NOT NULL AND basic_question_id IS NULL)
+    )
+);
+
+CREATE INDEX idx_question_sets_created_by ON question_sets (created_by);
+CREATE INDEX idx_question_set_items_question_set_id ON question_set_items (question_set_id);
+CREATE INDEX idx_question_set_items_basic_question_id ON question_set_items (basic_question_id);
+CREATE INDEX idx_question_set_items_set_answer_question_id ON question_set_items (set_answer_question_id);

--- a/api/src/main/resources/db/migration/mariadb/V4__init_question_sets.sql
+++ b/api/src/main/resources/db/migration/mariadb/V4__init_question_sets.sql
@@ -1,0 +1,31 @@
+CREATE TABLE question_sets (
+    id BINARY(16) PRIMARY KEY DEFAULT (uuid_v4()),
+    created_by BINARY(16) NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_question_sets_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE question_set_items (
+    id BINARY(16) PRIMARY KEY DEFAULT (uuid_v4()),
+    question_set_id BINARY(16) NOT NULL,
+    position INT NOT NULL CHECK (position > 0),
+    question_type VARCHAR(50) NOT NULL CHECK (question_type IN ('BASIC', 'SET_ANSWER')),
+    basic_question_id BINARY(16),
+    set_answer_question_id BINARY(16),
+    CONSTRAINT fk_question_set_items_question_set_id FOREIGN KEY (question_set_id) REFERENCES question_sets(id) ON DELETE CASCADE,
+    CONSTRAINT fk_question_set_items_basic_question_id FOREIGN KEY (basic_question_id) REFERENCES basic_questions(id) ON DELETE CASCADE,
+    CONSTRAINT fk_question_set_items_set_answer_question_id FOREIGN KEY (set_answer_question_id) REFERENCES set_answer_questions(id) ON DELETE CASCADE,
+    CONSTRAINT uq_question_set_items_position UNIQUE (question_set_id, position),
+    CONSTRAINT chk_question_set_items_question_reference CHECK (
+        (question_type = 'BASIC' AND basic_question_id IS NOT NULL AND set_answer_question_id IS NULL)
+        OR
+        (question_type = 'SET_ANSWER' AND set_answer_question_id IS NOT NULL AND basic_question_id IS NULL)
+    )
+);
+
+CREATE INDEX idx_question_sets_created_by ON question_sets (created_by);
+CREATE INDEX idx_question_set_items_question_set_id ON question_set_items (question_set_id);
+CREATE INDEX idx_question_set_items_basic_question_id ON question_set_items (basic_question_id);
+CREATE INDEX idx_question_set_items_set_answer_question_id ON question_set_items (set_answer_question_id);

--- a/api/src/main/resources/db/migration/postgres/V6__init_question_sets.sql
+++ b/api/src/main/resources/db/migration/postgres/V6__init_question_sets.sql
@@ -1,0 +1,27 @@
+CREATE TABLE question_sets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE question_set_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  question_set_id UUID NOT NULL REFERENCES question_sets(id) ON DELETE CASCADE,
+  position INT NOT NULL CHECK (position > 0),
+  question_type TEXT NOT NULL CHECK (question_type IN ('BASIC', 'SET_ANSWER')),
+  basic_question_id UUID REFERENCES basic_questions(id) ON DELETE CASCADE,
+  set_answer_question_id UUID REFERENCES set_answer_questions(id) ON DELETE CASCADE,
+  UNIQUE (question_set_id, position),
+  CHECK (
+    (question_type = 'BASIC' AND basic_question_id IS NOT NULL AND set_answer_question_id IS NULL)
+    OR
+    (question_type = 'SET_ANSWER' AND set_answer_question_id IS NOT NULL AND basic_question_id IS NULL)
+  )
+);
+
+CREATE INDEX idx_question_sets_created_by ON question_sets (created_by);
+CREATE INDEX idx_question_set_items_question_set_id ON question_set_items (question_set_id);
+CREATE INDEX idx_question_set_items_basic_question_id ON question_set_items (basic_question_id);
+CREATE INDEX idx_question_set_items_set_answer_question_id ON question_set_items (set_answer_question_id);

--- a/api/src/test/java/com/blanchaert/quizle/domain/question/QuestionSetServiceUnitTest.java
+++ b/api/src/test/java/com/blanchaert/quizle/domain/question/QuestionSetServiceUnitTest.java
@@ -1,0 +1,133 @@
+package com.blanchaert.quizle.domain.question;
+
+import com.blanchaert.quizle.domain.quiz.QuestionSet;
+import com.blanchaert.quizle.domain.quiz.QuestionSetQuestionType;
+import com.blanchaert.quizle.domain.quiz.QuestionSetRepository;
+import com.blanchaert.quizle.domain.quiz.QuestionSetService;
+import com.blanchaert.quizle.domain.user.Role;
+import com.blanchaert.quizle.domain.user.User;
+import com.blanchaert.quizle.domain.user.UserRepository;
+import com.blanchaert.quizle.dto.quiz.CreateQuestionSetQuestionRequest;
+import com.blanchaert.quizle.dto.quiz.CreateQuestionSetRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Tag("unit")
+class QuestionSetServiceUnitTest {
+
+    private QuestionSetRepository questionSetRepository;
+    private BasicQuestionRepository basicQuestionRepository;
+    private SetAnswerQuestionRepository setAnswerQuestionRepository;
+    private UserRepository userRepository;
+    private QuestionSetService questionSetService;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        questionSetRepository = mock(QuestionSetRepository.class);
+        basicQuestionRepository = mock(BasicQuestionRepository.class);
+        setAnswerQuestionRepository = mock(SetAnswerQuestionRepository.class);
+        userRepository = mock(UserRepository.class);
+        questionSetService = new QuestionSetService(
+                questionSetRepository,
+                basicQuestionRepository,
+                setAnswerQuestionRepository,
+                userRepository
+        );
+
+        user = new User();
+        user.setId(UUID.randomUUID());
+        user.setUsername("teacher");
+        user.setEmail("teacher@example.com");
+        user.setPasswordHash("hash");
+        user.setRole(Role.USER);
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("teacher", "password", List.of())
+        );
+        when(userRepository.findByUsername("teacher")).thenReturn(Optional.of(user));
+        when(basicQuestionRepository.save(any(BasicQuestion.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(setAnswerQuestionRepository.save(any(SetAnswerQuestion.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(questionSetRepository.save(any(QuestionSet.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createQuestionSet_savesOrderedMixedQuestionsForAuthenticatedUser() {
+        CreateQuestionSetRequest request = new CreateQuestionSetRequest();
+        request.setTitle(" OSI model ");
+        request.setDescription(" Networking basics ");
+        request.setQuestions(List.of(
+                basicQuestion(" In what layer of the OSI model resides TCP? ", " 4 "),
+                setAnswerQuestion(
+                        "Give me all layers of the OSI model.",
+                        7,
+                        List.of("Physical", "Data Link", "Network", "Transport", "Session", "Presentation", "Application")
+                )
+        ));
+
+        questionSetService.createQuestionSet(request);
+
+        ArgumentCaptor<QuestionSet> questionSetCaptor = ArgumentCaptor.forClass(QuestionSet.class);
+        verify(questionSetRepository).save(questionSetCaptor.capture());
+        QuestionSet savedSet = questionSetCaptor.getValue();
+
+        assertEquals("OSI model", savedSet.getTitle());
+        assertEquals("Networking basics", savedSet.getDescription());
+        assertEquals(user, savedSet.getCreatedBy());
+        assertEquals(2, savedSet.getQuestions().size());
+        assertEquals(1, savedSet.getQuestions().getFirst().getPosition());
+        assertEquals(QuestionSetQuestionType.BASIC, savedSet.getQuestions().getFirst().getQuestionType());
+        assertEquals("In what layer of the OSI model resides TCP?", savedSet.getQuestions().getFirst().getBasicQuestion().getQuestion());
+        assertEquals("4", savedSet.getQuestions().getFirst().getBasicQuestion().getAnswer());
+        assertEquals(2, savedSet.getQuestions().get(1).getPosition());
+        assertEquals(QuestionSetQuestionType.SET_ANSWER, savedSet.getQuestions().get(1).getQuestionType());
+        assertEquals(7, savedSet.getQuestions().get(1).getSetAnswerQuestion().getRequiredAnswers());
+    }
+
+    @Test
+    void createQuestionSet_rejectsSetAnswerQuestionWhenRequiredAnswersExceedAvailableAnswers() {
+        CreateQuestionSetRequest request = new CreateQuestionSetRequest();
+        request.setTitle("Broken quiz");
+        request.setQuestions(List.of(setAnswerQuestion("Name layers", 3, List.of("Physical", "Data Link"))));
+
+        assertThrows(IllegalArgumentException.class, () -> questionSetService.createQuestionSet(request));
+    }
+
+    private CreateQuestionSetQuestionRequest basicQuestion(String question, String answer) {
+        CreateQuestionSetQuestionRequest request = new CreateQuestionSetQuestionRequest();
+        request.setType(QuestionSetQuestionType.BASIC);
+        request.setQuestion(question);
+        request.setAnswer(answer);
+        return request;
+    }
+
+    private CreateQuestionSetQuestionRequest setAnswerQuestion(String question, int requiredAnswers, List<String> answers) {
+        CreateQuestionSetQuestionRequest request = new CreateQuestionSetQuestionRequest();
+        request.setType(QuestionSetQuestionType.SET_ANSWER);
+        request.setQuestion(question);
+        request.setRequiredAnswers(requiredAnswers);
+        request.setAnswers(answers);
+        return request;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a way to author quiz-style question sets that combine multiple ordered questions (e.g. a single-answer OSI-layer question followed by a complete-list OSI layers question). 
- Reuse existing `BASIC` and `SET_ANSWER` question types so users can create and persist mixed ordered quizzes for future attempt tracking.

### Description
- Add domain model for question sets with `QuestionSet`, `QuestionSetItem`, and `QuestionSetQuestionType`, and a `QuestionSetRepository` to persist sets. 
- Implement `QuestionSetService` to create, validate, trim and persist ordered mixed questions, and to produce `QuestionSetResponse` DTOs. 
- Add REST API controller `QuestionSetController` exposing `/api/question-sets` with `POST` to create sets and `GET` endpoints to list and fetch sets. 
- Add request/response DTOs under `dto.quiz` (`CreateQuestionSetRequest`, `CreateQuestionSetQuestionRequest`, `QuestionSetResponse`, `QuestionSetQuestionResponse`) and Flyway migrations for PostgreSQL/CockroachDB/MariaDB to create `question_sets` and `question_set_items`. 
- Add unit tests covering creation of mixed question sets and validation of set-answer requirements, and update README feature list to document the new APIs.

### Testing
- Ran `git diff --cached --check` and no staged whitespace/check issues were reported. 
- Attempted `./mvnw test` but the Maven wrapper could not download the Maven distribution in this environment (network/download failure). 
- Attempted `mvn test` but the build failed resolving the Spring Boot parent POM from Maven Central (HTTP 403). 
- Attempted `mvn -o test` (offline) but the parent POM was not available in the local cache, so tests could not be executed here; unit tests were added but not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0713eef4c4832fbf24f6cf59fc0f19)